### PR TITLE
Add automated NuGet publishing with GitVersion-based semantic versioning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,6 @@ jobs:
 
   publish:
     needs: build
-    if: github.event_name == 'push'
     runs-on: windows-latest
     permissions:
       contents: read

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,3 @@
-# This workflow will build a .NET project
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
-
 name: Build
 
 on:
@@ -11,39 +8,24 @@ on:
 
 jobs:
   build:
+    name: "Build, Test and Publish"
 
     runs-on: windows-latest
-    strategy:
-      matrix:
-        dotnet-version: [ '6.0.x', '7.0.x', '8.0.x', '9.0.x', '10.0.x' ]
 
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-    - name: Setup .NET ${{ matrix.dotnet-version }}
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: ${{ matrix.dotnet-version }}
-    - name: Restore dependencies
-      run: dotnet restore src/Verify.GemBox.sln
-    - name: Build
-      run: dotnet build src/Verify.GemBox.sln --no-restore
-    - name: Test
-      run: dotnet test src/Verify.GemBox.sln --no-build --verbosity normal
+    env:
+      DOTNET_NOLOGO: true
 
-  publish:
-    needs: build
-    runs-on: windows-latest
     permissions:
       contents: read
       id-token: write
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 0
-    - uses: actions/setup-dotnet@v4
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 10.0.x
 
@@ -67,22 +49,22 @@ jobs:
       run: dotnet restore src/Verify.GemBox.sln
 
     - name: Build
-      run: dotnet build src/Verify.GemBox.sln --no-restore --configuration Release /p:Version=${{ steps.version_step.outputs.FullSemVer }}
+      run: dotnet build src/Verify.GemBox.sln --no-restore --configuration Release /p:Version=${{ steps.transformed_version_step.outputs.NuGetSemVer }}
+
+    - name: Test
+      run: dotnet test src/Verify.GemBox.sln --no-build --configuration Release --verbosity normal
 
     - name: Pack
-      run: dotnet pack src/Verify.GemBox.sln --no-build --configuration Release --output ./nupkgs /p:Version=${{ steps.transformed_version_step.outputs.NuGetSemVer }}
+      run: dotnet pack src/Verify.GemBox.sln --no-build --configuration Release /p:Version=${{ steps.transformed_version_step.outputs.NuGetSemVer }}
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
 
     - name: NuGet login (OIDC → temp API key)
       uses: NuGet/login@v1
       id: login
       with:
         user: ${{ secrets.NUGET_USER }}
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
 
     - name: Push to NuGet
-      shell: pwsh
-      run: |
-        Get-ChildItem ./nupkgs -Filter *.nupkg | ForEach-Object {
-          dotnet nuget push $_.FullName `
-            --api-key "${{ steps.login.outputs.NUGET_API_KEY }}" `
-            --source https://api.nuget.org/v3/index.json
-        }
+      run: dotnet nuget push "**/bin/Release/*.nupkg" --api-key "${{ steps.login.outputs.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
       run: dotnet restore src/Verify.GemBox.sln
 
     - name: Build
-      run: dotnet build src/Verify.GemBox.sln --no-restore --configuration Release /p:Version=${{ steps.transformed_version_step.outputs.NuGetSemVer }}
+      run: dotnet build src/Verify.GemBox.sln --no-restore --configuration Release /p:Version=${{ steps.version_step.outputs.FullSemVer }}
 
     - name: Test
       run: dotnet test src/Verify.GemBox.sln --no-build --configuration Release --verbosity normal

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
     - name: Push to NuGet
       shell: pwsh
       run: |
-        Get-ChildItem ./nupkgs -Filter *.nupkg | ForEach-Object {
+        Get-ChildItem ./nupkgs -Filter Verify.GemBox*.nupkg | ForEach-Object {
           dotnet nuget push $_.FullName `
             --api-key "${{ steps.login.outputs.NUGET_API_KEY }}" `
             --source https://api.nuget.org/v3/index.json

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,6 @@ name: Build
 
 on:
   push:
-    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 
@@ -25,9 +24,11 @@ jobs:
         fetch-depth: 0
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: 10.0.x
+        global-json-file: "./global.json"
+        cache: true
+        cache-dependency-path: "**/packages.lock.json"
 
     - name: Install GitVersion
       uses: gittools/actions/gitversion/setup@v4.2.0
@@ -55,16 +56,16 @@ jobs:
       run: dotnet test src/Verify.GemBox.sln --no-build --configuration Release --verbosity normal
 
     - name: Pack
-      run: dotnet pack src/Verify.GemBox.sln --no-build --configuration Release /p:Version=${{ steps.transformed_version_step.outputs.NuGetSemVer }}
-      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      run: dotnet pack --no-build --configuration Release --include-symbols /p:Version=${{ steps.transformed_version_step.outputs.NuGetSemVer }} /p:SymbolPackageFormat=snupkg
+      if: github.event_name == 'push'
 
     - name: NuGet login (OIDC → temp API key)
       uses: NuGet/login@v1
       id: login
       with:
         user: ${{ secrets.NUGET_USER }}
-      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      if: github.event_name == 'push'
 
     - name: Push to NuGet
       run: dotnet nuget push "**/bin/Release/*.nupkg" --api-key "${{ steps.login.outputs.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json
-      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      if: github.event_name == 'push'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
       with:
-        global-json-file: "./global.json"
+        global-json-file: "./src/global.json"
         cache: true
         cache-dependency-path: "**/packages.lock.json"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - name: Setup .NET ${{ matrix.dotnet-version }}
       uses: actions/setup-dotnet@v4
       with:
@@ -29,3 +31,59 @@ jobs:
       run: dotnet build src/Verify.GemBox.sln --no-restore
     - name: Test
       run: dotnet test src/Verify.GemBox.sln --no-build --verbosity normal
+
+  publish:
+    needs: build
+    if: github.event_name == 'push'
+    runs-on: windows-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 10.0.x
+
+    - name: Install GitVersion
+      uses: gittools/actions/gitversion/setup@v4.2.0
+      with:
+        versionSpec: '6.6.x'
+
+    - name: Determine Version
+      id: version_step
+      uses: gittools/actions/gitversion/execute@v4.2.0
+
+    - name: Transform Version
+      id: transformed_version_step
+      shell: pwsh
+      run: |
+        $version = "${{ steps.version_step.outputs.FullSemVer }}" -replace '\+', '-'
+        echo "NuGetSemVer=$version" >> $env:GITHUB_OUTPUT
+
+    - name: Restore dependencies
+      run: dotnet restore src/Verify.GemBox.sln
+
+    - name: Build
+      run: dotnet build src/Verify.GemBox.sln --no-restore --configuration Release /p:Version=${{ steps.version_step.outputs.FullSemVer }}
+
+    - name: Pack
+      run: dotnet pack src/Verify.GemBox.sln --no-build --configuration Release --output ./nupkgs /p:Version=${{ steps.transformed_version_step.outputs.NuGetSemVer }}
+
+    - name: NuGet login (OIDC → temp API key)
+      uses: NuGet/login@v1
+      id: login
+      with:
+        user: ${{ secrets.NUGET_USER }}
+
+    - name: Push to NuGet
+      shell: pwsh
+      run: |
+        Get-ChildItem ./nupkgs -Filter *.nupkg | ForEach-Object {
+          dotnet nuget push $_.FullName `
+            --api-key "${{ steps.login.outputs.NUGET_API_KEY }}" `
+            --source https://api.nuget.org/v3/index.json
+        }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
       run: dotnet test src/Verify.GemBox.sln --no-build --configuration Release --verbosity normal
 
     - name: Pack
-      run: dotnet pack --no-build --configuration Release --include-symbols /p:Version=${{ steps.transformed_version_step.outputs.NuGetSemVer }} /p:SymbolPackageFormat=snupkg
+      run: dotnet pack src/Verify.GemBox.sln --no-build --configuration Release --include-symbols /p:Version=${{ steps.transformed_version_step.outputs.NuGetSemVer }} /p:SymbolPackageFormat=snupkg
       if: github.event_name == 'push'
 
     - name: NuGet login (OIDC → temp API key)

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,0 +1,1 @@
+workflow: GitHubFlow/v1

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
-    <NoWarn>CS1591;CS0649</NoWarn>
     <Version>2.2.0</Version>
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <LangVersion>preview</LangVersion>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
-    <Version>2.2.0</Version>
-    <AssemblyVersion>1.0.0</AssemblyVersion>
     <LangVersion>preview</LangVersion>
     <PackageTags>GemBox, Verify</PackageTags>
     <Description>Extends Verify (https://github.com/VerifyTests/Verify) to allow verification via GemBox.</Description>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,0 +1,5 @@
+<Project>
+	<PropertyGroup>
+		<WarningsNotAsErrors>$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
+	</PropertyGroup>
+</Project>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,5 +1,0 @@
-<Project>
-  <PropertyGroup>
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
-  </PropertyGroup>
-</Project>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,5 +1,5 @@
 <Project>
-	<PropertyGroup>
-		<WarningsNotAsErrors>$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
-	</PropertyGroup>
+  <PropertyGroup>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
+  </PropertyGroup>
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -4,17 +4,17 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="GemBox.Document" Version="2026.2.100" />
-    <PackageVersion Include="GemBox.Pdf" Version="2026.2.100" />
-    <PackageVersion Include="GemBox.Presentation" Version="2026.2.100" />
-    <PackageVersion Include="GemBox.Spreadsheet" Version="2026.2.100" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageVersion Include="NUnit" Version="4.5.0" />
+    <PackageVersion Include="GemBox.Document" Version="2026.3.103" />
+    <PackageVersion Include="GemBox.Pdf" Version="2026.3.102" />
+    <PackageVersion Include="GemBox.Presentation" Version="2026.3.103" />
+    <PackageVersion Include="GemBox.Spreadsheet" Version="2026.3.103" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageVersion Include="NUnit" Version="4.5.1" />
     <PackageVersion Include="NUnit3TestAdapter" Version="6.1.0" />
-    <PackageVersion Include="ProjectDefaults" Version="1.0.144" />
+    <PackageVersion Include="ProjectDefaults" Version="1.0.172" />
     <PackageVersion Include="Verify" Version="31.13.2" />
     <PackageVersion Include="Verify.DiffPlex" Version="3.1.2" />
-    <PackageVersion Include="Verify.ImageMagick" Version="3.8.4" />
+    <PackageVersion Include="Verify.ImageMagick" Version="3.8.6" />
     <PackageVersion Include="Verify.NUnit" Version="31.13.2" />
   </ItemGroup>
 </Project>

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net10.0-windows</TargetFramework>
     <SignAssembly>False</SignAssembly>
+    <IsPackable>false</IsPackable>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
   </PropertyGroup>
 

--- a/src/Tests/packages.lock.json
+++ b/src/Tests/packages.lock.json
@@ -4,19 +4,19 @@
     "net10.0-windows7.0": {
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
-        "requested": "[18.0.1, )",
-        "resolved": "18.0.1",
-        "contentHash": "WNpu6vI2rA0pXY4r7NKxCN16XRWl5uHu6qjuyVLoDo6oYEggIQefrMjkRuibQHm/NslIUNCcKftvoWAN80MSAg==",
+        "requested": "[18.3.0, )",
+        "resolved": "18.3.0",
+        "contentHash": "xW3kXuWRQtgoxJp4J+gdhHSQyK+6Wb/AZDSd7lMvuMRYlZ1tnpkojyfZlWilB5G4dmZ0Y0ZxU/M23TlubndNkw==",
         "dependencies": {
-          "Microsoft.CodeCoverage": "18.0.1",
-          "Microsoft.TestPlatform.TestHost": "18.0.1"
+          "Microsoft.CodeCoverage": "18.3.0",
+          "Microsoft.TestPlatform.TestHost": "18.3.0"
         }
       },
       "NUnit": {
         "type": "Direct",
-        "requested": "[4.5.0, )",
-        "resolved": "4.5.0",
-        "contentHash": "3AXYqXoll1CnWA+fNqMQemJO5qofh2r75bdrPyJqjCRCcZpwuCAgUnHxG1wKEbrGjtobrWWbwVrDhYcXcxRkjw=="
+        "requested": "[4.5.1, )",
+        "resolved": "4.5.1",
+        "contentHash": "x1sIqU9i0IkxqFayqthzmJs/75jTMbrfNMixj4vtfTi7rRzGbtuY27V+iAhfTY02u5k2qvW3QBGM414OG4q8Lw=="
       },
       "NUnit3TestAdapter": {
         "type": "Direct",
@@ -30,9 +30,9 @@
       },
       "ProjectDefaults": {
         "type": "Direct",
-        "requested": "[1.0.144, )",
-        "resolved": "1.0.144",
-        "contentHash": "69ZM0pUvDThooM9g5o5EjKhB8nTwf+n3Xl8LAb+y/8UwmZaLaRzKgqDAyA+haQ8ZxC78dOUxOamVnGpRB2rlqw=="
+        "requested": "[1.0.172, )",
+        "resolved": "1.0.172",
+        "contentHash": "LcvsGpapPm363YBewK2Wq/BAULjXOcu93GV7rOx8uPlkUsA5Y29chi8F/J0P0cWBkQdkZPR2eblB0UGnJS30lA=="
       },
       "Verify.DiffPlex": {
         "type": "Direct",
@@ -46,14 +46,14 @@
       },
       "Verify.ImageMagick": {
         "type": "Direct",
-        "requested": "[3.8.4, )",
-        "resolved": "3.8.4",
-        "contentHash": "5/Wt7ASgxOJJcl5tPkRqdIpDqGjElso/bSUBSLs08DM3SfKOCr2GsCsUpfmKbkouL3j/nH36RuyUT7h3k9lP2g==",
+        "requested": "[3.8.6, )",
+        "resolved": "3.8.6",
+        "contentHash": "G1AOMyAz3JNposbHFMIZeNHjD7dLTYxXA7YKW/QKk7UXblmNlIRXpWflRajoDEfHehFuMxOPQl0GEL/geIZdeg==",
         "dependencies": {
           "Argon": "0.33.5",
-          "DiffEngine": "18.4.2",
+          "DiffEngine": "19.0.0",
           "EmptyFiles": "8.17.2",
-          "Magick.NET-Q16-AnyCPU": "14.10.3",
+          "Magick.NET-Q16-AnyCPU": "14.11.0",
           "SimpleInfoName": "3.2.0",
           "Verify": "31.13.2"
         }
@@ -83,8 +83,8 @@
       },
       "DiffEngine": {
         "type": "Transitive",
-        "resolved": "18.4.2",
-        "contentHash": "wF6X6muxUEqJNEsrzM/EKqN47wCHp7M5oQkze8hjg7SwTuUxso+RZmUJZIOcVilMCjXnNXn0xOxyqoqZYoAs8Q==",
+        "resolved": "19.0.0",
+        "contentHash": "QtT6bdSW93UwE3f3vy5/qQRQIGtybA6uU1qyF4NvlCUga4esTTA6T4o8gENj2s8YJX8wh1MR10L6ypQ8A5dFAg==",
         "dependencies": {
           "EmptyFiles": "8.17.2"
         }
@@ -120,16 +120,16 @@
       },
       "Magick.NET-Q16-AnyCPU": {
         "type": "Transitive",
-        "resolved": "14.10.3",
-        "contentHash": "kSMjee72iMUxoZJrEO0hnNTBYXrBBAO0sauVjK2p92gRFO5v6sWUCuSIUruRAd6OBOm3vlFHbrx2uQkA/EJMwQ==",
+        "resolved": "14.11.0",
+        "contentHash": "L6IvAG7scg/nma67v0JUTKL9SOpu5FY7O9W3SElMTPm4Iu62/KC3A+rGa5KwUletRXsjf67RaAhDh47/fug2rg==",
         "dependencies": {
-          "Magick.NET.Core": "14.10.3"
+          "Magick.NET.Core": "14.11.0"
         }
       },
       "Magick.NET.Core": {
         "type": "Transitive",
-        "resolved": "14.10.3",
-        "contentHash": "Shb3KrAMFB49+j7nJ2uVbNBuGg+rEAoOpIDmR2A/sSbQ21l4vrPY8Py90chcndGcjzvhqZWk69SMmb8v5esOjA=="
+        "resolved": "14.11.0",
+        "contentHash": "MdNdyZJ7CjTV0zc4G1dGz8RIis5ZizYOMRrQ4+WghHYq5Hn151VNPPFpRsZ3fw61klegTFbzYRyMQjfl/sYW3w=="
       },
       "Microsoft.ApplicationInsights": {
         "type": "Transitive",
@@ -138,8 +138,8 @@
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
-        "resolved": "18.0.1",
-        "contentHash": "O+utSr97NAJowIQT/OVp3Lh9QgW/wALVTP4RG1m2AfFP4IyJmJz0ZBmFJUsRQiAPgq6IRC0t8AAzsiPIsaUDEA=="
+        "resolved": "18.3.0",
+        "contentHash": "23BNy/vziREC20Wwhb50K7+kZe0m07KlLWDQv4qjJ9tt3QjpDpDIqJFrhYHmMEo9xDkuSp55U/8h4bMF7MiB+g=="
       },
       "Microsoft.Testing.Extensions.Telemetry": {
         "type": "Transitive",
@@ -190,15 +190,15 @@
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
-        "resolved": "18.0.1",
-        "contentHash": "qT/mwMcLF9BieRkzOBPL2qCopl8hQu6A1P7JWAoj/FMu5i9vds/7cjbJ/LLtaiwWevWLAeD5v5wjQJ/l6jvhWQ=="
+        "resolved": "18.3.0",
+        "contentHash": "AEIEX2aWdPO9XbtR96eBaJxmXRD9vaI9uQ1T/JbPEKlTAZwYx0ZrMzKyULMdh/HH9Sg03kXCoN7LszQ90o6nPQ=="
       },
       "Microsoft.TestPlatform.TestHost": {
         "type": "Transitive",
-        "resolved": "18.0.1",
-        "contentHash": "uDJKAEjFTaa2wHdWlfo6ektyoh+WD4/Eesrwb4FpBFKsLGehhACVnwwTI4qD3FrIlIEPlxdXg3SyrYRIcO+RRQ==",
+        "resolved": "18.3.0",
+        "contentHash": "twmsoelXnp1uWMU3VGip9f0Jr1mZ0PZqgJdF35CIrdYgYrkHIJMV1m8uKyhcdjLdsQDESHAgkR7KhS9i1qpJag==",
         "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "18.0.1",
+          "Microsoft.TestPlatform.ObjectModel": "18.3.0",
           "Newtonsoft.Json": "13.0.3"
         }
       },
@@ -252,18 +252,18 @@
       "verify.gembox": {
         "type": "Project",
         "dependencies": {
-          "GemBox.Document": "[2026.2.100, )",
-          "GemBox.Pdf": "[2026.2.100, )",
-          "GemBox.Presentation": "[2026.2.100, )",
-          "GemBox.Spreadsheet": "[2026.2.100, )",
+          "GemBox.Document": "[2026.3.103, )",
+          "GemBox.Pdf": "[2026.3.102, )",
+          "GemBox.Presentation": "[2026.3.103, )",
+          "GemBox.Spreadsheet": "[2026.3.103, )",
           "Verify": "[31.13.2, )"
         }
       },
       "GemBox.Document": {
         "type": "CentralTransitive",
-        "requested": "[2026.2.100, )",
-        "resolved": "2026.2.100",
-        "contentHash": "RpHGpyvbxBJViTdVsmFnEvc1NQIjm/mNoj1K1ZMefNDNvqmI6/ZOuxBjT+50kRANN5SuXbcFyguaTIgn0gQopA==",
+        "requested": "[2026.3.103, )",
+        "resolved": "2026.3.103",
+        "contentHash": "YX7IyZRs6cFGzmxQibXnUKhNUmj/FywUKQ3PRWB9R9TrdmnFxp3+g7JAdO94kMT8Fl6zEbvnRGuZq3SNAcc19g==",
         "dependencies": {
           "BouncyCastle.Cryptography": "2.4.0",
           "HarfBuzzSharp": "7.3.0.3",
@@ -273,9 +273,9 @@
       },
       "GemBox.Pdf": {
         "type": "CentralTransitive",
-        "requested": "[2026.2.100, )",
-        "resolved": "2026.2.100",
-        "contentHash": "Th3S19QWoN+52GT2K9zcl2XhyrKjNTlAtT0AnzhTMbhr7k6pbfhZFtUedGAlZGeCH2mBO1K0m9/Q9NgVp3zBng==",
+        "requested": "[2026.3.102, )",
+        "resolved": "2026.3.102",
+        "contentHash": "LUqokT7XvCONWIe4hL3oOjLyypI47tRAsthCloXu7Z9x+VjaIVS+LlcKhiqXuQg4fzmN4IC6N2gBNr8AjvbovA==",
         "dependencies": {
           "BouncyCastle.Cryptography": "2.4.0",
           "HarfBuzzSharp": "7.3.0.3",
@@ -286,9 +286,9 @@
       },
       "GemBox.Presentation": {
         "type": "CentralTransitive",
-        "requested": "[2026.2.100, )",
-        "resolved": "2026.2.100",
-        "contentHash": "PwVVQf2EQ4nNJmovrhYvw9sZxQ4mioLKMv0uJTKfj2onVWTxQnUynMZx5qYljZJt/N+gZOgHJto0isk+RupZ5A==",
+        "requested": "[2026.3.103, )",
+        "resolved": "2026.3.103",
+        "contentHash": "it2AcJSuBZYB6iY/cneEdgZ8ZZW8bNpKc90574aiOlNzNAkh6kXgcAzf3GgyBh+f55X/XzE/wIacJuuQ10phdQ==",
         "dependencies": {
           "BouncyCastle.Cryptography": "2.4.0",
           "SkiaSharp": "2.88.9",
@@ -297,9 +297,9 @@
       },
       "GemBox.Spreadsheet": {
         "type": "CentralTransitive",
-        "requested": "[2026.2.100, )",
-        "resolved": "2026.2.100",
-        "contentHash": "Zz9YhBlMIeLKdNA5mb4/2GnRFMBHvHlmL4Aibl62WYByzXIlZjDiCPzfZgQG98b1/o0o/2GVHlofeKWsIU7S2g==",
+        "requested": "[2026.3.103, )",
+        "resolved": "2026.3.103",
+        "contentHash": "4AT84JRaKzjEhffS2B1ChBpWX0PU/G1vHcGb6JqZCWxqZ+BQ1GcdbMazmx2UJyd9bXdhn4tC4CSNS3BwFAonMQ==",
         "dependencies": {
           "BouncyCastle.Cryptography": "2.4.0",
           "HarfBuzzSharp": "7.3.0.3",

--- a/src/Verify.GemBox.sln
+++ b/src/Verify.GemBox.sln
@@ -14,7 +14,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\.gitignore = ..\.gitignore
 		..\.github\workflows\build.yml = ..\.github\workflows\build.yml
 		Directory.Build.props = Directory.Build.props
-		Directory.Build.targets = Directory.Build.targets
 		Directory.Packages.props = Directory.Packages.props
 		global.json = global.json
 		..\readme.md = ..\readme.md

--- a/src/Verify.GemBox.sln
+++ b/src/Verify.GemBox.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 18
-VisualStudioVersion = 18.4.11519.219 insiders
+VisualStudioVersion = 18.4.11519.219
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Verify.GemBox", "Verify.GemBox\Verify.GemBox.csproj", "{C16C0072-7126-47FB-9546-13FE14267B8E}"
 EndProject
@@ -12,9 +12,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 		.gitattributes = .gitattributes
 		..\.gitignore = ..\.gitignore
-		appveyor.yml = appveyor.yml
 		..\.github\workflows\build.yml = ..\.github\workflows\build.yml
 		Directory.Build.props = Directory.Build.props
+		Directory.Build.targets = Directory.Build.targets
 		Directory.Packages.props = Directory.Packages.props
 		..\readme.md = ..\readme.md
 	EndProjectSection

--- a/src/Verify.GemBox.sln
+++ b/src/Verify.GemBox.sln
@@ -16,6 +16,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Directory.Build.props = Directory.Build.props
 		Directory.Build.targets = Directory.Build.targets
 		Directory.Packages.props = Directory.Packages.props
+		global.json = global.json
 		..\readme.md = ..\readme.md
 	EndProjectSection
 EndProject

--- a/src/Verify.GemBox/packages.lock.json
+++ b/src/Verify.GemBox/packages.lock.json
@@ -4,9 +4,9 @@
     ".NETFramework,Version=v4.8": {
       "GemBox.Document": {
         "type": "Direct",
-        "requested": "[2026.2.100, )",
-        "resolved": "2026.2.100",
-        "contentHash": "RpHGpyvbxBJViTdVsmFnEvc1NQIjm/mNoj1K1ZMefNDNvqmI6/ZOuxBjT+50kRANN5SuXbcFyguaTIgn0gQopA==",
+        "requested": "[2026.3.103, )",
+        "resolved": "2026.3.103",
+        "contentHash": "YX7IyZRs6cFGzmxQibXnUKhNUmj/FywUKQ3PRWB9R9TrdmnFxp3+g7JAdO94kMT8Fl6zEbvnRGuZq3SNAcc19g==",
         "dependencies": {
           "BouncyCastle.Cryptography": "2.4.0",
           "HarfBuzzSharp": "7.3.0.3",
@@ -19,9 +19,9 @@
       },
       "GemBox.Pdf": {
         "type": "Direct",
-        "requested": "[2026.2.100, )",
-        "resolved": "2026.2.100",
-        "contentHash": "Th3S19QWoN+52GT2K9zcl2XhyrKjNTlAtT0AnzhTMbhr7k6pbfhZFtUedGAlZGeCH2mBO1K0m9/Q9NgVp3zBng==",
+        "requested": "[2026.3.102, )",
+        "resolved": "2026.3.102",
+        "contentHash": "LUqokT7XvCONWIe4hL3oOjLyypI47tRAsthCloXu7Z9x+VjaIVS+LlcKhiqXuQg4fzmN4IC6N2gBNr8AjvbovA==",
         "dependencies": {
           "BouncyCastle.Cryptography": "2.4.0",
           "HarfBuzzSharp": "7.3.0.3",
@@ -35,9 +35,9 @@
       },
       "GemBox.Presentation": {
         "type": "Direct",
-        "requested": "[2026.2.100, )",
-        "resolved": "2026.2.100",
-        "contentHash": "PwVVQf2EQ4nNJmovrhYvw9sZxQ4mioLKMv0uJTKfj2onVWTxQnUynMZx5qYljZJt/N+gZOgHJto0isk+RupZ5A==",
+        "requested": "[2026.3.103, )",
+        "resolved": "2026.3.103",
+        "contentHash": "it2AcJSuBZYB6iY/cneEdgZ8ZZW8bNpKc90574aiOlNzNAkh6kXgcAzf3GgyBh+f55X/XzE/wIacJuuQ10phdQ==",
         "dependencies": {
           "BouncyCastle.Cryptography": "2.4.0",
           "Microsoft.Bcl.Numerics": "9.0.0",
@@ -49,9 +49,9 @@
       },
       "GemBox.Spreadsheet": {
         "type": "Direct",
-        "requested": "[2026.2.100, )",
-        "resolved": "2026.2.100",
-        "contentHash": "Zz9YhBlMIeLKdNA5mb4/2GnRFMBHvHlmL4Aibl62WYByzXIlZjDiCPzfZgQG98b1/o0o/2GVHlofeKWsIU7S2g==",
+        "requested": "[2026.3.103, )",
+        "resolved": "2026.3.103",
+        "contentHash": "4AT84JRaKzjEhffS2B1ChBpWX0PU/G1vHcGb6JqZCWxqZ+BQ1GcdbMazmx2UJyd9bXdhn4tC4CSNS3BwFAonMQ==",
         "dependencies": {
           "BouncyCastle.Cryptography": "2.4.0",
           "HarfBuzzSharp": "7.3.0.3",
@@ -221,9 +221,9 @@
     "net10.0": {
       "GemBox.Document": {
         "type": "Direct",
-        "requested": "[2026.2.100, )",
-        "resolved": "2026.2.100",
-        "contentHash": "RpHGpyvbxBJViTdVsmFnEvc1NQIjm/mNoj1K1ZMefNDNvqmI6/ZOuxBjT+50kRANN5SuXbcFyguaTIgn0gQopA==",
+        "requested": "[2026.3.103, )",
+        "resolved": "2026.3.103",
+        "contentHash": "YX7IyZRs6cFGzmxQibXnUKhNUmj/FywUKQ3PRWB9R9TrdmnFxp3+g7JAdO94kMT8Fl6zEbvnRGuZq3SNAcc19g==",
         "dependencies": {
           "HarfBuzzSharp": "7.3.0.3",
           "HarfBuzzSharp.NativeAssets.Linux": "7.3.0.3",
@@ -235,9 +235,9 @@
       },
       "GemBox.Pdf": {
         "type": "Direct",
-        "requested": "[2026.2.100, )",
-        "resolved": "2026.2.100",
-        "contentHash": "Th3S19QWoN+52GT2K9zcl2XhyrKjNTlAtT0AnzhTMbhr7k6pbfhZFtUedGAlZGeCH2mBO1K0m9/Q9NgVp3zBng==",
+        "requested": "[2026.3.102, )",
+        "resolved": "2026.3.102",
+        "contentHash": "LUqokT7XvCONWIe4hL3oOjLyypI47tRAsthCloXu7Z9x+VjaIVS+LlcKhiqXuQg4fzmN4IC6N2gBNr8AjvbovA==",
         "dependencies": {
           "HarfBuzzSharp": "7.3.0.3",
           "HarfBuzzSharp.NativeAssets.Linux": "7.3.0.3",
@@ -250,9 +250,9 @@
       },
       "GemBox.Presentation": {
         "type": "Direct",
-        "requested": "[2026.2.100, )",
-        "resolved": "2026.2.100",
-        "contentHash": "PwVVQf2EQ4nNJmovrhYvw9sZxQ4mioLKMv0uJTKfj2onVWTxQnUynMZx5qYljZJt/N+gZOgHJto0isk+RupZ5A==",
+        "requested": "[2026.3.103, )",
+        "resolved": "2026.3.103",
+        "contentHash": "it2AcJSuBZYB6iY/cneEdgZ8ZZW8bNpKc90574aiOlNzNAkh6kXgcAzf3GgyBh+f55X/XzE/wIacJuuQ10phdQ==",
         "dependencies": {
           "Microsoft.Bcl.Numerics": "9.0.0",
           "Portable.BouncyCastle": "1.9.0",
@@ -262,9 +262,9 @@
       },
       "GemBox.Spreadsheet": {
         "type": "Direct",
-        "requested": "[2026.2.100, )",
-        "resolved": "2026.2.100",
-        "contentHash": "Zz9YhBlMIeLKdNA5mb4/2GnRFMBHvHlmL4Aibl62WYByzXIlZjDiCPzfZgQG98b1/o0o/2GVHlofeKWsIU7S2g==",
+        "requested": "[2026.3.103, )",
+        "resolved": "2026.3.103",
+        "contentHash": "4AT84JRaKzjEhffS2B1ChBpWX0PU/G1vHcGb6JqZCWxqZ+BQ1GcdbMazmx2UJyd9bXdhn4tC4CSNS3BwFAonMQ==",
         "dependencies": {
           "HarfBuzzSharp": "7.3.0.3",
           "HarfBuzzSharp.NativeAssets.Linux": "7.3.0.3",
@@ -381,9 +381,9 @@
     "net6.0": {
       "GemBox.Document": {
         "type": "Direct",
-        "requested": "[2026.2.100, )",
-        "resolved": "2026.2.100",
-        "contentHash": "RpHGpyvbxBJViTdVsmFnEvc1NQIjm/mNoj1K1ZMefNDNvqmI6/ZOuxBjT+50kRANN5SuXbcFyguaTIgn0gQopA==",
+        "requested": "[2026.3.103, )",
+        "resolved": "2026.3.103",
+        "contentHash": "YX7IyZRs6cFGzmxQibXnUKhNUmj/FywUKQ3PRWB9R9TrdmnFxp3+g7JAdO94kMT8Fl6zEbvnRGuZq3SNAcc19g==",
         "dependencies": {
           "HarfBuzzSharp": "7.3.0.3",
           "HarfBuzzSharp.NativeAssets.Linux": "7.3.0.3",
@@ -395,9 +395,9 @@
       },
       "GemBox.Pdf": {
         "type": "Direct",
-        "requested": "[2026.2.100, )",
-        "resolved": "2026.2.100",
-        "contentHash": "Th3S19QWoN+52GT2K9zcl2XhyrKjNTlAtT0AnzhTMbhr7k6pbfhZFtUedGAlZGeCH2mBO1K0m9/Q9NgVp3zBng==",
+        "requested": "[2026.3.102, )",
+        "resolved": "2026.3.102",
+        "contentHash": "LUqokT7XvCONWIe4hL3oOjLyypI47tRAsthCloXu7Z9x+VjaIVS+LlcKhiqXuQg4fzmN4IC6N2gBNr8AjvbovA==",
         "dependencies": {
           "HarfBuzzSharp": "7.3.0.3",
           "HarfBuzzSharp.NativeAssets.Linux": "7.3.0.3",
@@ -410,9 +410,9 @@
       },
       "GemBox.Presentation": {
         "type": "Direct",
-        "requested": "[2026.2.100, )",
-        "resolved": "2026.2.100",
-        "contentHash": "PwVVQf2EQ4nNJmovrhYvw9sZxQ4mioLKMv0uJTKfj2onVWTxQnUynMZx5qYljZJt/N+gZOgHJto0isk+RupZ5A==",
+        "requested": "[2026.3.103, )",
+        "resolved": "2026.3.103",
+        "contentHash": "it2AcJSuBZYB6iY/cneEdgZ8ZZW8bNpKc90574aiOlNzNAkh6kXgcAzf3GgyBh+f55X/XzE/wIacJuuQ10phdQ==",
         "dependencies": {
           "Microsoft.Bcl.Numerics": "9.0.0",
           "Portable.BouncyCastle": "1.9.0",
@@ -422,9 +422,9 @@
       },
       "GemBox.Spreadsheet": {
         "type": "Direct",
-        "requested": "[2026.2.100, )",
-        "resolved": "2026.2.100",
-        "contentHash": "Zz9YhBlMIeLKdNA5mb4/2GnRFMBHvHlmL4Aibl62WYByzXIlZjDiCPzfZgQG98b1/o0o/2GVHlofeKWsIU7S2g==",
+        "requested": "[2026.3.103, )",
+        "resolved": "2026.3.103",
+        "contentHash": "4AT84JRaKzjEhffS2B1ChBpWX0PU/G1vHcGb6JqZCWxqZ+BQ1GcdbMazmx2UJyd9bXdhn4tC4CSNS3BwFAonMQ==",
         "dependencies": {
           "HarfBuzzSharp": "7.3.0.3",
           "HarfBuzzSharp.NativeAssets.Linux": "7.3.0.3",
@@ -552,9 +552,9 @@
     "net7.0": {
       "GemBox.Document": {
         "type": "Direct",
-        "requested": "[2026.2.100, )",
-        "resolved": "2026.2.100",
-        "contentHash": "RpHGpyvbxBJViTdVsmFnEvc1NQIjm/mNoj1K1ZMefNDNvqmI6/ZOuxBjT+50kRANN5SuXbcFyguaTIgn0gQopA==",
+        "requested": "[2026.3.103, )",
+        "resolved": "2026.3.103",
+        "contentHash": "YX7IyZRs6cFGzmxQibXnUKhNUmj/FywUKQ3PRWB9R9TrdmnFxp3+g7JAdO94kMT8Fl6zEbvnRGuZq3SNAcc19g==",
         "dependencies": {
           "HarfBuzzSharp": "7.3.0.3",
           "HarfBuzzSharp.NativeAssets.Linux": "7.3.0.3",
@@ -566,9 +566,9 @@
       },
       "GemBox.Pdf": {
         "type": "Direct",
-        "requested": "[2026.2.100, )",
-        "resolved": "2026.2.100",
-        "contentHash": "Th3S19QWoN+52GT2K9zcl2XhyrKjNTlAtT0AnzhTMbhr7k6pbfhZFtUedGAlZGeCH2mBO1K0m9/Q9NgVp3zBng==",
+        "requested": "[2026.3.102, )",
+        "resolved": "2026.3.102",
+        "contentHash": "LUqokT7XvCONWIe4hL3oOjLyypI47tRAsthCloXu7Z9x+VjaIVS+LlcKhiqXuQg4fzmN4IC6N2gBNr8AjvbovA==",
         "dependencies": {
           "HarfBuzzSharp": "7.3.0.3",
           "HarfBuzzSharp.NativeAssets.Linux": "7.3.0.3",
@@ -581,9 +581,9 @@
       },
       "GemBox.Presentation": {
         "type": "Direct",
-        "requested": "[2026.2.100, )",
-        "resolved": "2026.2.100",
-        "contentHash": "PwVVQf2EQ4nNJmovrhYvw9sZxQ4mioLKMv0uJTKfj2onVWTxQnUynMZx5qYljZJt/N+gZOgHJto0isk+RupZ5A==",
+        "requested": "[2026.3.103, )",
+        "resolved": "2026.3.103",
+        "contentHash": "it2AcJSuBZYB6iY/cneEdgZ8ZZW8bNpKc90574aiOlNzNAkh6kXgcAzf3GgyBh+f55X/XzE/wIacJuuQ10phdQ==",
         "dependencies": {
           "Microsoft.Bcl.Numerics": "9.0.0",
           "Portable.BouncyCastle": "1.9.0",
@@ -593,9 +593,9 @@
       },
       "GemBox.Spreadsheet": {
         "type": "Direct",
-        "requested": "[2026.2.100, )",
-        "resolved": "2026.2.100",
-        "contentHash": "Zz9YhBlMIeLKdNA5mb4/2GnRFMBHvHlmL4Aibl62WYByzXIlZjDiCPzfZgQG98b1/o0o/2GVHlofeKWsIU7S2g==",
+        "requested": "[2026.3.103, )",
+        "resolved": "2026.3.103",
+        "contentHash": "4AT84JRaKzjEhffS2B1ChBpWX0PU/G1vHcGb6JqZCWxqZ+BQ1GcdbMazmx2UJyd9bXdhn4tC4CSNS3BwFAonMQ==",
         "dependencies": {
           "HarfBuzzSharp": "7.3.0.3",
           "HarfBuzzSharp.NativeAssets.Linux": "7.3.0.3",
@@ -723,9 +723,9 @@
     "net8.0": {
       "GemBox.Document": {
         "type": "Direct",
-        "requested": "[2026.2.100, )",
-        "resolved": "2026.2.100",
-        "contentHash": "RpHGpyvbxBJViTdVsmFnEvc1NQIjm/mNoj1K1ZMefNDNvqmI6/ZOuxBjT+50kRANN5SuXbcFyguaTIgn0gQopA==",
+        "requested": "[2026.3.103, )",
+        "resolved": "2026.3.103",
+        "contentHash": "YX7IyZRs6cFGzmxQibXnUKhNUmj/FywUKQ3PRWB9R9TrdmnFxp3+g7JAdO94kMT8Fl6zEbvnRGuZq3SNAcc19g==",
         "dependencies": {
           "HarfBuzzSharp": "7.3.0.3",
           "HarfBuzzSharp.NativeAssets.Linux": "7.3.0.3",
@@ -737,9 +737,9 @@
       },
       "GemBox.Pdf": {
         "type": "Direct",
-        "requested": "[2026.2.100, )",
-        "resolved": "2026.2.100",
-        "contentHash": "Th3S19QWoN+52GT2K9zcl2XhyrKjNTlAtT0AnzhTMbhr7k6pbfhZFtUedGAlZGeCH2mBO1K0m9/Q9NgVp3zBng==",
+        "requested": "[2026.3.102, )",
+        "resolved": "2026.3.102",
+        "contentHash": "LUqokT7XvCONWIe4hL3oOjLyypI47tRAsthCloXu7Z9x+VjaIVS+LlcKhiqXuQg4fzmN4IC6N2gBNr8AjvbovA==",
         "dependencies": {
           "HarfBuzzSharp": "7.3.0.3",
           "HarfBuzzSharp.NativeAssets.Linux": "7.3.0.3",
@@ -752,9 +752,9 @@
       },
       "GemBox.Presentation": {
         "type": "Direct",
-        "requested": "[2026.2.100, )",
-        "resolved": "2026.2.100",
-        "contentHash": "PwVVQf2EQ4nNJmovrhYvw9sZxQ4mioLKMv0uJTKfj2onVWTxQnUynMZx5qYljZJt/N+gZOgHJto0isk+RupZ5A==",
+        "requested": "[2026.3.103, )",
+        "resolved": "2026.3.103",
+        "contentHash": "it2AcJSuBZYB6iY/cneEdgZ8ZZW8bNpKc90574aiOlNzNAkh6kXgcAzf3GgyBh+f55X/XzE/wIacJuuQ10phdQ==",
         "dependencies": {
           "Microsoft.Bcl.Numerics": "9.0.0",
           "Portable.BouncyCastle": "1.9.0",
@@ -764,9 +764,9 @@
       },
       "GemBox.Spreadsheet": {
         "type": "Direct",
-        "requested": "[2026.2.100, )",
-        "resolved": "2026.2.100",
-        "contentHash": "Zz9YhBlMIeLKdNA5mb4/2GnRFMBHvHlmL4Aibl62WYByzXIlZjDiCPzfZgQG98b1/o0o/2GVHlofeKWsIU7S2g==",
+        "requested": "[2026.3.103, )",
+        "resolved": "2026.3.103",
+        "contentHash": "4AT84JRaKzjEhffS2B1ChBpWX0PU/G1vHcGb6JqZCWxqZ+BQ1GcdbMazmx2UJyd9bXdhn4tC4CSNS3BwFAonMQ==",
         "dependencies": {
           "HarfBuzzSharp": "7.3.0.3",
           "HarfBuzzSharp.NativeAssets.Linux": "7.3.0.3",
@@ -883,9 +883,9 @@
     "net9.0": {
       "GemBox.Document": {
         "type": "Direct",
-        "requested": "[2026.2.100, )",
-        "resolved": "2026.2.100",
-        "contentHash": "RpHGpyvbxBJViTdVsmFnEvc1NQIjm/mNoj1K1ZMefNDNvqmI6/ZOuxBjT+50kRANN5SuXbcFyguaTIgn0gQopA==",
+        "requested": "[2026.3.103, )",
+        "resolved": "2026.3.103",
+        "contentHash": "YX7IyZRs6cFGzmxQibXnUKhNUmj/FywUKQ3PRWB9R9TrdmnFxp3+g7JAdO94kMT8Fl6zEbvnRGuZq3SNAcc19g==",
         "dependencies": {
           "HarfBuzzSharp": "7.3.0.3",
           "HarfBuzzSharp.NativeAssets.Linux": "7.3.0.3",
@@ -897,9 +897,9 @@
       },
       "GemBox.Pdf": {
         "type": "Direct",
-        "requested": "[2026.2.100, )",
-        "resolved": "2026.2.100",
-        "contentHash": "Th3S19QWoN+52GT2K9zcl2XhyrKjNTlAtT0AnzhTMbhr7k6pbfhZFtUedGAlZGeCH2mBO1K0m9/Q9NgVp3zBng==",
+        "requested": "[2026.3.102, )",
+        "resolved": "2026.3.102",
+        "contentHash": "LUqokT7XvCONWIe4hL3oOjLyypI47tRAsthCloXu7Z9x+VjaIVS+LlcKhiqXuQg4fzmN4IC6N2gBNr8AjvbovA==",
         "dependencies": {
           "HarfBuzzSharp": "7.3.0.3",
           "HarfBuzzSharp.NativeAssets.Linux": "7.3.0.3",
@@ -912,9 +912,9 @@
       },
       "GemBox.Presentation": {
         "type": "Direct",
-        "requested": "[2026.2.100, )",
-        "resolved": "2026.2.100",
-        "contentHash": "PwVVQf2EQ4nNJmovrhYvw9sZxQ4mioLKMv0uJTKfj2onVWTxQnUynMZx5qYljZJt/N+gZOgHJto0isk+RupZ5A==",
+        "requested": "[2026.3.103, )",
+        "resolved": "2026.3.103",
+        "contentHash": "it2AcJSuBZYB6iY/cneEdgZ8ZZW8bNpKc90574aiOlNzNAkh6kXgcAzf3GgyBh+f55X/XzE/wIacJuuQ10phdQ==",
         "dependencies": {
           "Microsoft.Bcl.Numerics": "9.0.0",
           "Portable.BouncyCastle": "1.9.0",
@@ -924,9 +924,9 @@
       },
       "GemBox.Spreadsheet": {
         "type": "Direct",
-        "requested": "[2026.2.100, )",
-        "resolved": "2026.2.100",
-        "contentHash": "Zz9YhBlMIeLKdNA5mb4/2GnRFMBHvHlmL4Aibl62WYByzXIlZjDiCPzfZgQG98b1/o0o/2GVHlofeKWsIU7S2g==",
+        "requested": "[2026.3.103, )",
+        "resolved": "2026.3.103",
+        "contentHash": "4AT84JRaKzjEhffS2B1ChBpWX0PU/G1vHcGb6JqZCWxqZ+BQ1GcdbMazmx2UJyd9bXdhn4tC4CSNS3BwFAonMQ==",
         "dependencies": {
           "HarfBuzzSharp": "7.3.0.3",
           "HarfBuzzSharp.NativeAssets.Linux": "7.3.0.3",

--- a/src/global.json
+++ b/src/global.json
@@ -1,7 +1,10 @@
 ﻿{
   "sdk": {
-    "version": "10.0.103",
+    "version": "10.0.201",
     "allowPrerelease": true,
-    "rollForward": "latestFeature"
+    "rollForward": "latestPatch"
+  },
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
   }
 }


### PR DESCRIPTION
This pull request updates the build pipeline and dependencies for the project, focusing on modernizing the CI workflow and ensuring compatibility with the latest package versions. The changes streamline versioning, package management, and publishing, while also updating solution and project configuration files.

**Build and CI Workflow Improvements:**

* Replaced the matrix-based build setup in `.github/workflows/build.yml` with a more streamlined workflow that uses `global.json` for .NET version management, adds versioning via GitVersion, and automates packing and publishing to NuGet on push events. The workflow now uses updated actions and includes caching and OIDC authentication for secure NuGet publishing.
* Added `GitVersion.yml` to configure GitVersion for versioning in CI.

**Dependency Updates:**

* Updated GemBox packages (`GemBox.Document`, `GemBox.Pdf`, `GemBox.Presentation`, `GemBox.Spreadsheet`) and several test-related packages (`Microsoft.NET.Test.Sdk`, `NUnit`, `ProjectDefaults`, `Verify.ImageMagick`) to their latest versions in `src/Directory.Packages.props` and lock files (`src/Tests/packages.lock.json`, `src/Verify.GemBox/packages.lock.json`).

**Project and Solution Configuration:**

* Removed explicit versioning and warning suppression from `src/Directory.Build.props`, shifting version control to CI and package management.
* Added `IsPackable=false` to `src/Tests/Tests.csproj` to prevent test projects from being packed/published.
* Updated `src/Verify.GemBox.sln` to remove the "insiders" tag from Visual Studio version and include `global.json` in solution items for improved .NET version management.

These changes modernize the build and release process, improve reliability, and ensure the project uses up-to-date dependencies and tools.